### PR TITLE
V3.0 - Minimize

### DIFF
--- a/src/modules/diffOps.js
+++ b/src/modules/diffOps.js
@@ -1,0 +1,4 @@
+
+  async function retrieveData({targetHashsum}){
+  return fs.readFile(muOps.path('disk_mem', 'bin', gl.insert(targetHashsum, 2, '/')))
+}

--- a/src/modules/fileOps.js
+++ b/src/modules/fileOps.js
@@ -22,7 +22,6 @@ module.exports = {
   fdiff
 }
 
-
 function fdiff(str1, str2, fast=false) {
 
   const splitIt = str => {
@@ -68,7 +67,7 @@ function fdiff(str1, str2, fast=false) {
   }
 }
 
-async function getFileMostRecentSave(fp){
+async function getFileMostRecentSave(fp) {
   const currentTree = await treeOps.getSavedData(po.head)
 
   const hashes = Object.keys(currentTree.dat)
@@ -76,7 +75,7 @@ async function getFileMostRecentSave(fp){
     const data = currentTree.dat[hash]
     const isutf8 = data[0]
     if(Object.keys(data[2]).some(k => (k === fp)) && isutf8){
-      return retrieveData({'targetHashsum': hash, isutf8})
+      return retrieveData({'targetHashsum': hash})
     }
   }
   return false
@@ -94,8 +93,18 @@ async function retrieveData({targetHashsum}){
   return fs.readFile(muOps.path('disk_mem', 'bin', gl.insert(targetHashsum, 2, '/')))
 }
 
-async function writeFile({fp, targetHashsum, isutf8, mtime}) {
-  await fs.outputFile(fp, await retrieveData({targetHashsum}))
+function getReadStream({targetHashsum}) {
+  return fs.createReadStream(muOps.path('disk_mem', 'bin', gl.insert(targetHashsum, 2, '/')))
+}
+
+async function writeFile({fp, targetHashsum, mtime}) {
+  const readStream = getReadStream({targetHashsum})
+  const writeStream = fs.createWriteStream(fp)
+
+  readStream.pipe(writeStream)
+  await (new Promise(resolve => {
+    writeStream.on('finish', resolve)
+  }))
   await fs.utimes(fp, Date.now()/1000, mtime)
 
   print(chalk.green(`✓\t${fp}`))

--- a/src/modules/fileOps.js
+++ b/src/modules/fileOps.js
@@ -90,19 +90,12 @@ async function remove({fp}) {
   }
 }
 
-async function retrieveData({targetHashsum, isutf8}){
-  const getUtf8Data = async () => {
-    const fileArray = await fs.readJson(muOps.path('disk_mem', 'files', gl.insert(targetHashsum, 2, '/')), 'utf8')
-    const fileLines = await Promise.all(fileArray.map(linehash => fs.readFile(muOps.path('disk_mem', 'lines', gl.insert(linehash, 2, '/')), 'utf8')))
-    return fileLines.join('')
-  }
-  const getBinaryData = () => fs.readFile(muOps.path('disk_mem', 'bin', gl.insert(targetHashsum, 2, '/')))
-
-  return isutf8 ? getUtf8Data() : getBinaryData()
+async function retrieveData({targetHashsum}){
+  return fs.readFile(muOps.path('disk_mem', 'bin', gl.insert(targetHashsum, 2, '/')))
 }
 
 async function writeFile({fp, targetHashsum, isutf8, mtime}) {
-  await fs.outputFile(fp, await retrieveData({targetHashsum, isutf8}))
+  await fs.outputFile(fp, await retrieveData({targetHashsum}))
   await fs.utimes(fp, Date.now()/1000, mtime)
 
   print(chalk.green(`✓\t${fp}`))

--- a/src/modules/hashOps.js
+++ b/src/modules/hashOps.js
@@ -24,33 +24,15 @@ function hashIt(buffer) {
 }
 
 /**
-* @description caches lines & file to disk and returns the hashsum key for file
+* @description caches files to disk and returns the hashsum key for file
 * @param {String} fpath - file path
 * @returns {String} hashsum
 */
 function diskCache(GlMem, buffer, isutf8) {
-  const isUncached = hash => !(GlMem.memory.has(hash))
-  const cacheIt = data => {
-    GlMem.memory.add(data)
-  }
-
   const fileHash = hashIt(buffer)
-  if(!isutf8){
+  if(!(GlMem.memory.has(fileHash))) {
+    GlMem.memory.add(fileHash)
     GlMem.binQueue.push([path.join(muOps.to.bin, gl.insert(fileHash, 2, '/')), buffer])
-  }else{
-    const file = buffer.toString('utf8')
-    if (isUncached(fileHash)) {
-      cacheIt(fileHash)
-      const hashes = file.split(gl.eol).map((line, _, arrayOfLines) => {
-        const lineHash = hashIt(line)
-        if (isUncached(lineHash) || arrayOfLines.length === 1) {
-          cacheIt(lineHash)
-          GlMem.lineQueue.push([path.join(muOps.to.lines, gl.insert(lineHash, 2, '/')), line])
-        }
-        return lineHash
-      })
-      GlMem.fileQueue.push([path.join(muOps.to.files, gl.insert(fileHash, 2, '/')), hashes])
-    }
   }
   return fileHash
 }

--- a/src/modules/muOps.js
+++ b/src/modules/muOps.js
@@ -44,8 +44,6 @@ async function update() {
     muOps.isPath = isPath
     muOps.path = getPath
     muOps.to = {
-      lines: getPath('disk_mem', 'lines'),
-      files: getPath('disk_mem', 'files'),
       bin: getPath('disk_mem', 'bin')
     }
   }

--- a/src/utils/simpleSet.js
+++ b/src/utils/simpleSet.js
@@ -1,0 +1,14 @@
+module.exports = () => {
+  const simpleset = {}
+  return {
+    add(val) {
+      simpleset[val] = true
+    },
+    has(val) {
+      return typeof simpleset[val] !== 'undefined'
+    },
+    remove(val) {
+      delete e[val]
+    }
+  }
+}


### PR DESCRIPTION
BREAKING CHANGE

So the whole big idea _originally_ was that this VC tool would super prioritize hand-written ascii data. We can now treat each line of text as a thing that we might want to reuse. I've basically realized that git was right and indexing each file is probably the way to go given how much data is not plaintext. This PR changes MU to index on file instead of by line which makes the logic simpler and produces _way_ fewer temp files (which I have to believe makes things run quicker).